### PR TITLE
feat(authentication): implement signup UI view

### DIFF
--- a/amistad-client/package-lock.json
+++ b/amistad-client/package-lock.json
@@ -8389,6 +8389,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",

--- a/amistad-client/package.json
+++ b/amistad-client/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.0",
     "dayjs": "^1.8.18",
+    "jwt-decode": "^2.2.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",

--- a/amistad-client/src/App.js
+++ b/amistad-client/src/App.js
@@ -1,32 +1,33 @@
-import React from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import { ThemeProvider as MuiThemeProvider} from '@material-ui/core/styles';
-import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
-import './App.css';
+import React from "react";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { ThemeProvider as MuiThemeProvider } from "@material-ui/core/styles";
+import createMuiTheme from "@material-ui/core/styles/createMuiTheme";
+import jwtDecode from "jwt-decode";
+import "./App.css";
+import appTheme from "./util/theme";
+import AuthRoute from "./util/AuthRoute";
 
 //Components
-import Navbar from './components/Navbar';
+import Navbar from "./components/Navbar";
 // Pages
-import home from './pages/home';
-import signup from './pages/signup';
-import login from './pages/login';
+import home from "./pages/home";
+import signup from "./pages/signup";
+import login from "./pages/login";
 
-const theme = createMuiTheme({
-  palette: {
-    primary: {
-      light: '#33c9dc',
-      dark: '#008394',
-      main: '#00bcd4',
-      contrastText: '#fff'
-    },
-    secondary: {
-      light: '#ff6333',
-      dark: '#ff3d00',
-      main: '#b22a00',
-      contrastText: '#fff'
-    }
+const theme = createMuiTheme(appTheme);
+
+let authenticated;
+
+const token = localStorage.amistadToken;
+if (token) {
+  const decodedToken = jwtDecode(token);
+  if (decodedToken.exp * 1000 < Date.now()) {
+    window.location.href("/login");
+    authenticated = false;
+  } else {
+    authenticated = true;
   }
-})
+}
 
 function App() {
   return (
@@ -37,8 +38,18 @@ function App() {
           <div className="container">
             <Switch>
               <Route exact path="/" component={home} />
-              <Route exact path="/signup" component={signup} />
-              <Route exact path="/login" component={login} />
+              <AuthRoute
+                exact
+                path="/signup"
+                component={signup}
+                authenticated={authenticated}
+              />
+              <AuthRoute
+                exact
+                path="/login"
+                component={login}
+                authenticated={authenticated}
+              />
             </Switch>
           </div>
         </Router>

--- a/amistad-client/src/pages/login.js
+++ b/amistad-client/src/pages/login.js
@@ -1,115 +1,121 @@
-import React, { useState } from 'react';
-import withStyles from '@material-ui/core/styles/withStyles';
-import Typography from '@material-ui/core/Typography';
-import TextField from '@material-ui/core/TextField';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import Button from '@material-ui/core/Button';
-import PropTypes from 'prop-types';
-import AppIcon from '../images/amistad-icon.png';
-import axios from 'axios';
-import Grid from '@material-ui/core/Grid';
-import { Link } from 'react-router-dom';
+import React, { useState } from "react";
+import withStyles from "@material-ui/core/styles/withStyles";
+import Typography from "@material-ui/core/Typography";
+import TextField from "@material-ui/core/TextField";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import Button from "@material-ui/core/Button";
+import PropTypes from "prop-types";
+import AppIcon from "../images/amistad-icon.png";
+import axios from "axios";
+import Grid from "@material-ui/core/Grid";
+import { Link } from "react-router-dom";
 
-
-const styles = {
-  form: {
-    textAlign: 'center'
-  },
-  image: {
-    margin: '20px auto 0 auto',
-    width: '52px',
-    height: '52px'
-  },
-  pageTitle: {
-    margin: '10px auto 10px auto',
-  },
-  textField: {
-    margin: '10px auto 10px auto',
-  },
-  button: {
-    marginTop: 20,
-    position: 'relative'
-  },
-  progress: {
-    position: 'absolute'
-  },
-  customError: {
-    color: 'red',
-    fontSize: '0.8rem',
-    marginTop: 10
-  }
-}
-
+const styles = theme => ({
+  ...theme.otherStyling
+});
 
 function Login({ classes, history }) {
   const initialState = {
-    email: '',
-    password: '',
+    email: "",
+    password: "",
     isLoading: false,
     errors: {}
   };
   const [formValues, setFormValues] = useState(initialState);
-  const handleSubmit = async (event) => {
+  const handleSubmit = async event => {
     try {
       event.preventDefault();
       setFormValues({
         ...formValues,
-        email: '',
-        password: '',
+        email: "",
+        password: "",
         isLoading: true
       });
-      const { data: token } = await axios.post('/login',
-      {
+      const {
+        data: { token }
+      } = await axios.post("/login", {
         email: formValues.email,
         password: formValues.password
       });
       setFormValues({
         ...formValues,
-        email: '',
-        password: '',
+        email: "",
+        password: "",
         isLoading: false
       });
-      history.push('/');
+      console.log(token);
+      await localStorage.setItem("amistadToken", `Bearer ${token}`);
+      history.push("/");
     } catch (error) {
       console.log(error.response.data);
       setFormValues({
         ...formValues,
-        email: '',
-        password: '',
+        email: "",
+        password: "",
         errors: error.response.data
       });
     }
-  }
-  const handleFocus = (event) => {
+  };
+  const handleFocus = event => {
     setFormValues({
       ...formValues,
-      [event.target.name] : event.target.value,
+      [event.target.name]: event.target.value,
       errors: {}
     });
-  }
-  const handleChange = (event) => {
+  };
+  const handleChange = event => {
     setFormValues({
       ...formValues,
-      [event.target.name] : event.target.value
+      [event.target.name]: event.target.value
     });
-  }
+  };
   return (
     <Grid container className={classes.form}>
       <Grid item sm />
       <Grid item sm>
-        <img src={AppIcon} alt='App Icon' className={classes.image} />
-        <Typography variant='h2' className={classes.pageTitle}>
+        <img src={AppIcon} alt="App Icon" className={classes.image} />
+        <Typography variant="h2" className={classes.pageTitle}>
           Login
         </Typography>
         <form noValidate onSubmit={handleSubmit}>
-          <TextField id='email' name='email' type='email' label='Email' className={classes.textField} value={formValues.email} helperText={formValues.errors.email} error={formValues.errors.email ? true : false} onChange={handleChange} onFocus={handleFocus} fullWidth />
-          <TextField id='password' name='password' type='password' label='Password' className={classes.textField} value={formValues.password} helperText={formValues.errors.password} error={formValues.errors.password ? true : false} onChange={handleChange} onFocus={handleFocus} fullWidth />
+          <TextField
+            id="email"
+            name="email"
+            type="email"
+            label="Email"
+            className={classes.textField}
+            value={formValues.email}
+            helperText={formValues.errors.email}
+            error={formValues.errors.email ? true : false}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            fullWidth
+          />
+          <TextField
+            id="password"
+            name="password"
+            type="password"
+            label="Password"
+            className={classes.textField}
+            value={formValues.password}
+            helperText={formValues.errors.password}
+            error={formValues.errors.password ? true : false}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            fullWidth
+          />
           {formValues.errors.general && (
-            <Typography variant='body2' className={classes.customError}>
+            <Typography variant="body2" className={classes.customError}>
               {formValues.errors.general}
             </Typography>
           )}
-          <Button type='submit' variant='contained' color='primary' className={classes.button} disabled={formValues.isLoading}>
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            className={classes.button}
+            disabled={formValues.isLoading}
+          >
             Login
             {formValues.isLoading && (
               <CircularProgress size={30} className={classes.progress} />
@@ -117,17 +123,20 @@ function Login({ classes, history }) {
           </Button>
           <br />
           <small>
-            Don't have an account? Sign up <Link to='/signup' className='nav-links'>here</Link>
+            Don't have an account? Sign up{" "}
+            <Link to="/signup" className="nav-links">
+              here
+            </Link>
           </small>
         </form>
       </Grid>
       <Grid item sm />
     </Grid>
-  )
+  );
 }
 
 Login.propTypes = {
   classes: PropTypes.object.isRequired
-}
+};
 
 export default withStyles(styles)(Login);

--- a/amistad-client/src/pages/signup.js
+++ b/amistad-client/src/pages/signup.js
@@ -1,12 +1,181 @@
-import React from 'react'
+import React, { useState } from "react";
+import withStyles from "@material-ui/core/styles/withStyles";
+import Typography from "@material-ui/core/Typography";
+import TextField from "@material-ui/core/TextField";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import Button from "@material-ui/core/Button";
+import PropTypes from "prop-types";
+import AppIcon from "../images/amistad-icon.png";
+import axios from "axios";
+import Grid from "@material-ui/core/Grid";
+import { Link } from "react-router-dom";
 
-function signup() {
+const styles = theme => ({
+  ...theme.otherStyling
+});
+
+function Signup({ classes, history }) {
+  const initialState = {
+    email: "",
+    password: "",
+    confirmPassword: "",
+    handle: "",
+    isLoading: false,
+    errors: {}
+  };
+  const [formValues, setFormValues] = useState(initialState);
+  const handleSubmit = async event => {
+    try {
+      event.preventDefault();
+      setFormValues({
+        ...formValues,
+        email: "",
+        password: "",
+        confirmPassword: "",
+        handle: "",
+        isLoading: true
+      });
+      const {
+        data: { token }
+      } = await axios.post("/signup", {
+        email: formValues.email,
+        password: formValues.password,
+        confirmPassword: formValues.confirmPassword,
+        handle: formValues.handle
+      });
+      setFormValues({
+        ...formValues,
+        email: "",
+        password: "",
+        confirmPassword: "",
+        handle: "",
+        isLoading: false
+      });
+      await localStorage.setItem("amistadToken", `Bearer ${token}`);
+      history.push("/");
+    } catch (error) {
+      console.log(error.response.data);
+      setFormValues({
+        ...formValues,
+        email: "",
+        password: "",
+        confirmPassword: "",
+        handle: "",
+        errors: error.response.data
+      });
+    }
+  };
+  const handleFocus = event => {
+    setFormValues({
+      ...formValues,
+      [event.target.name]: event.target.value,
+      errors: {}
+    });
+  };
+  const handleChange = event => {
+    setFormValues({
+      ...formValues,
+      [event.target.name]: event.target.value
+    });
+  };
   return (
-    <div>
-      <h1>Signup Page</h1>
-    </div>
-  )
+    <Grid container className={classes.form}>
+      <Grid item sm />
+      <Grid item sm>
+        <img src={AppIcon} alt="App Icon" className={classes.image} />
+        <Typography variant="h2" className={classes.pageTitle}>
+          Signup
+        </Typography>
+        <form noValidate onSubmit={handleSubmit}>
+          <TextField
+            id="email"
+            name="email"
+            type="email"
+            label="Email"
+            className={classes.textField}
+            value={formValues.email}
+            helperText={formValues.errors.email}
+            error={formValues.errors.email ? true : false}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            fullWidth
+          />
+
+          <TextField
+            id="password"
+            name="password"
+            type="password"
+            label="Password"
+            className={classes.textField}
+            value={formValues.password}
+            helperText={formValues.errors.password}
+            error={formValues.errors.password ? true : false}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            fullWidth
+          />
+
+          <TextField
+            id="confirmPassword"
+            name="confirmPassword"
+            type="password"
+            label="Confirm Password"
+            className={classes.textField}
+            value={formValues.confirmPassword}
+            helperText={formValues.errors.confirmPassword}
+            error={formValues.errors.confirmPassword ? true : false}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            fullWidth
+          />
+
+          <TextField
+            id="handle"
+            name="handle"
+            type="text"
+            label="Handle"
+            className={classes.textField}
+            value={formValues.handle}
+            helperText={formValues.errors.handle}
+            error={formValues.errors.handle ? true : false}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            fullWidth
+          />
+
+          {formValues.errors.general && (
+            <Typography variant="body2" className={classes.customError}>
+              {formValues.errors.general}
+            </Typography>
+          )}
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            className={classes.button}
+            disabled={formValues.isLoading}
+          >
+            Signup
+            {formValues.isLoading && (
+              <CircularProgress size={30} className={classes.progress} />
+            )}
+          </Button>
+          <br />
+          <small>
+            Already have an account? Login{" "}
+            <Link to="/login" className="nav-links">
+              here
+            </Link>
+          </small>
+        </form>
+      </Grid>
+      <Grid item sm />
+    </Grid>
+  );
 }
 
-export default signup;
+Signup.propTypes = {
+  classes: PropTypes.object.isRequired
+};
 
+export default withStyles(styles)(Signup);

--- a/amistad-client/src/util/AuthRoute.js
+++ b/amistad-client/src/util/AuthRoute.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { Route, Redirect } from "react-router-dom";
+
+const AuthRoute = ({ component: Component, authenticated, ...rest }) => (
+  <Route
+    {...rest}
+    render={props =>
+      authenticated ? <Redirect to="/" /> : <Component {...props} />
+    }
+  />
+);
+
+export default AuthRoute;

--- a/amistad-client/src/util/theme.js
+++ b/amistad-client/src/util/theme.js
@@ -1,0 +1,47 @@
+export default {
+  palette: {
+    primary: {
+      light: '#33c9dc',
+      dark: '#008394',
+      main: '#00bcd4',
+      contrastText: '#fff'
+    },
+    secondary: {
+      light: '#ff6333',
+      dark: '#ff3d00',
+      main: '#b22a00',
+      contrastText: '#fff'
+    }
+  },
+  otherStyling: {
+    typography: {
+      useNextVariants: true
+    },
+    form: {
+      textAlign: 'center'
+    },
+    image: {
+      margin: '20px auto 0 auto',
+      width: '52px',
+      height: '52px'
+    },
+    pageTitle: {
+      margin: '10px auto 10px auto',
+    },
+    textField: {
+      margin: '10px auto 10px auto',
+    },
+    button: {
+      marginTop: 20,
+      position: 'relative'
+    },
+    progress: {
+      position: 'absolute'
+    },
+    customError: {
+      color: 'red',
+      fontSize: '0.8rem',
+      marginTop: 10
+    }
+  }
+};


### PR DESCRIPTION
## What does this PR do?
This PR implements the signup UI view of the application

## What major activities were carried out?
- create signup form component
- create form handlers to handle different events from the form
- style form components

## How can this be manually tested?
- Clone the repository
- Fetch the branch
- Install the dependencies
- cd into the `amistad-client` folder
- Start project by running `npm start` in the terminal
- Your browser should automatically load to show you the homepage screen below:

![homepage-with-scream-cards](https://user-images.githubusercontent.com/28527393/71390146-6d5e3480-25ff-11ea-9526-7987d9b60d1f.png)
- In the browser, add `/signup` to the url. You should see the following page:

![signup page](https://user-images.githubusercontent.com/28527393/71532515-fd4bf900-28f3-11ea-9fdf-6a60ad58ada6.png)

- Fill in the form details as appropriate, then submit. The browser should redirect to take you to the homepage with `screams`.