### PR TITLE
feat(profile): implements the profile card of user

### DIFF
--- a/amistad-client/package-lock.json
+++ b/amistad-client/package-lock.json
@@ -1272,6 +1272,14 @@
         "react-transition-group": "^4.3.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.5.1.tgz",
+      "integrity": "sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.7.1.tgz",
@@ -3122,7 +3130,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3495,7 +3504,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3543,6 +3553,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3581,11 +3592,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },

--- a/amistad-client/package.json
+++ b/amistad-client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.8.0",
+    "@material-ui/icons": "^4.5.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.0",
     "@testing-library/user-event": "^7.2.1",

--- a/amistad-client/src/App.js
+++ b/amistad-client/src/App.js
@@ -1,57 +1,14 @@
 import React from "react";
-import { Provider, useDispatch } from "react-redux";
-import axios from "axios";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import { ThemeProvider as MuiThemeProvider } from "@material-ui/core/styles";
-import createMuiTheme from "@material-ui/core/styles/createMuiTheme";
-import jwtDecode from "jwt-decode";
-import "./App.css";
-import appTheme from "./util/theme";
-import AuthRoute from "./util/AuthRoute";
+import { Provider } from "react-redux";
 import store from "./redux/store";
-import { SET_AUTHENTICATED } from "./redux/types";
-import { logoutUser, getUserData } from "./redux/actions/userActions";
+import MyApp from "./MyApp";
 
-//Components
-import Navbar from "./components/Navbar";
-// Pages
-import home from "./pages/home";
-import signup from "./pages/signup";
-import login from "./pages/login";
-
-const theme = createMuiTheme(appTheme);
-
-const token = localStorage.amistadToken;
-if (token) {
-  const dispatch = useDispatch();
-  const decodedToken = jwtDecode(token);
-  if (decodedToken.exp * 1000 < Date.now()) {
-    store.dispatch(logoutUser(dispatch));
-    window.location.href("/login");
-  } else {
-    store.dispatch({ type: SET_AUTHENTICATED });
-    axios.defaults.headers.common["Authorization"] = token;
-    store.dispatch(getUserData(dispatch));
-  }
-}
-
-function App() {
+const App = () => {
   return (
-    <MuiThemeProvider theme={theme}>
-      <Provider store={store}>
-        <Router>
-          <Navbar />
-          <div className="container">
-            <Switch>
-              <Route exact path="/" component={home} />
-              <AuthRoute exact path="/signup" component={signup} />
-              <AuthRoute exact path="/login" component={login} />
-            </Switch>
-          </div>
-        </Router>
-      </Provider>
-    </MuiThemeProvider>
+    <Provider store={store}>
+      <MyApp />
+    </Provider>
   );
-}
+};
 
 export default App;

--- a/amistad-client/src/MyApp.js
+++ b/amistad-client/src/MyApp.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { useDispatch } from "react-redux";
+import axios from "axios";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { ThemeProvider as MuiThemeProvider } from "@material-ui/core/styles";
+import createMuiTheme from "@material-ui/core/styles/createMuiTheme";
+import jwtDecode from "jwt-decode";
+import "./App.css";
+import appTheme from "./util/theme";
+import AuthRoute from "./util/AuthRoute";
+import { SET_AUTHENTICATED } from "./redux/types";
+import { logoutUser, getUserData } from "./redux/actions/userActions";
+
+//Components
+import Navbar from "./components/Navbar";
+// Pages
+import home from "./pages/home";
+import signup from "./pages/signup";
+import login from "./pages/login";
+
+const theme = createMuiTheme(appTheme);
+
+const MyApp = () => {
+  const dispatch = useDispatch();
+  const token = localStorage.amistadToken;
+  if (token) {
+    const decodedToken = jwtDecode(token);
+    if (decodedToken.exp * 1000 < Date.now()) {
+      logoutUser(dispatch);
+      window.location.href("/login");
+    } else {
+      dispatch({ type: SET_AUTHENTICATED });
+      axios.defaults.headers.common["Authorization"] = token;
+      getUserData(dispatch);
+    }
+  }
+  return (
+    <MuiThemeProvider theme={theme}>
+      <Router>
+        <Navbar />
+        <div className="container">
+          <Switch>
+            <Route exact path="/" component={home} />
+            <AuthRoute exact path="/signup" component={signup} />
+            <AuthRoute exact path="/login" component={login} />
+          </Switch>
+        </div>
+      </Router>
+    </MuiThemeProvider>
+  );
+};
+
+export default MyApp;

--- a/amistad-client/src/components/Profile.js
+++ b/amistad-client/src/components/Profile.js
@@ -1,0 +1,145 @@
+import React, { Fragment } from "react";
+import dayjs from "dayjs";
+import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
+import withStyles from "@material-ui/core/styles/withStyles";
+import Paper from "@material-ui/core/Paper";
+import MuiLink from "@material-ui/core/Link";
+import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
+import LocationOn from "@material-ui/icons/LocationOn";
+import LinkIcon from "@material-ui/icons/Link";
+import CalendarToday from "@material-ui/icons/CalendarToday";
+
+const styles = theme => ({
+  paper: {
+    padding: 20
+  },
+  profile: {
+    "& .image-wrapper": {
+      textAlign: "center",
+      position: "relative",
+      "& .button": {
+        position: "absolute",
+        top: "80%",
+        left: "70%"
+      }
+    },
+    "& .profile-image": {
+      width: 200,
+      height: 200,
+      objectFit: "cover",
+      maxWidth: "100%",
+      borderRadius: "50%"
+    },
+    "& .profile-details": {
+      textAlign: "center",
+      "& span, svg": {
+        verticalAlign: "middle"
+      },
+      "& a": {
+        color: theme.palette.primary.main
+      }
+    },
+    "& hr": {
+      border: "none",
+      margin: "0 0 10px 0"
+    },
+    "& svg.button": {
+      "&:hover": {
+        cursor: "pointer"
+      }
+    }
+  },
+  buttons: {
+    textAlign: "center",
+    "& a": {
+      margin: "20px 10px"
+    }
+  }
+});
+
+function Profile({ classes }) {
+  const {
+    credentials: { handle, createdAt, imageUrl, bio, website, location },
+    loading,
+    authenticated
+  } = useSelector(state => ({ ...state.user }));
+
+  return !loading ? (
+    authenticated ? (
+      <Paper className={classes.paper}>
+        <div className={classes.profile}>
+          <div className="image-wrapper">
+            <img src={imageUrl} alt="profile" className="profile-image" />
+          </div>
+          <hr />
+          <div className="profile-details">
+            <MuiLink
+              component={Link}
+              to={`/users/${handle}`}
+              color="primary"
+              variant="h5"
+            >
+              @{handle}
+            </MuiLink>
+            <hr />
+            {bio && (
+              <Fragment>
+                <Typography variant="body2">{bio}</Typography>
+                <hr />
+              </Fragment>
+            )}
+            {location && (
+              <Fragment>
+                <LocationOn color="primary" /> <span>{location}</span>
+                <hr />
+              </Fragment>
+            )}
+            {website && (
+              <Fragment>
+                <LinkIcon color="primary" />
+                <a href={website} target="_blank" rel="noopener noreferrer">
+                  {" "}
+                  {website}
+                </a>
+                <hr />
+              </Fragment>
+            )}
+            <CalendarToday color="primary" />{" "}
+            <span>Joined {dayjs(createdAt).format("MMM YYYY")}</span>
+          </div>
+        </div>
+      </Paper>
+    ) : (
+      <Paper className={classes.paper}>
+        <Typography variant="body2" align="center">
+          No profile found. Please login again
+        </Typography>
+        <div className={classes.buttons}>
+          <Button
+            variant="contained"
+            color="primary"
+            component={Link}
+            to={"/login"}
+          >
+            Login
+          </Button>
+          <Button
+            variant="contained"
+            color="secondary"
+            component={Link}
+            to={"/signup"}
+          >
+            Signup
+          </Button>
+        </div>
+      </Paper>
+    )
+  ) : (
+    <p>Loading...</p>
+  );
+  // return profileMarkup;
+}
+
+export default withStyles(styles)(Profile);

--- a/amistad-client/src/pages/home.js
+++ b/amistad-client/src/pages/home.js
@@ -1,29 +1,35 @@
-import React, { useState, useEffect } from 'react'
-import axios from 'axios';
-import Grid from '@material-ui/core/Grid';
-import Scream from '../components/Scream';
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import Grid from "@material-ui/core/Grid";
+import Scream from "../components/Scream";
+import Profile from "../components/Profile";
 
-function Home() {
+const Home = () => {
   const [screams, setScream] = useState([]);
-  
+
   useEffect(() => {
     const fetchData = async () => {
-      const { data: screams} = await axios.get('/screams');
+      const { data: screams } = await axios.get("/screams");
       setScream(screams);
-    }
+    };
     fetchData();
   }, []);
-  const recentScreamsMarkup = screams.length > 0 ? (screams.map(scream => <Scream key={scream.screamId} scream={scream} />)) : <p>Loading...</p>
+  const recentScreamsMarkup =
+    screams.length > 0 ? (
+      screams.map(scream => <Scream key={scream.screamId} scream={scream} />)
+    ) : (
+      <p>Loading...</p>
+    );
   return (
     <Grid container spacing={2}>
       <Grid item sm={8} xs={12}>
-      {recentScreamsMarkup}
+        {recentScreamsMarkup}
       </Grid>
       <Grid item sm={4} xs={12}>
-        <p>Profile...</p>
+        <Profile />
       </Grid>
     </Grid>
-  )
-}
+  );
+};
 
 export default Home;

--- a/amistad-client/src/pages/login.js
+++ b/amistad-client/src/pages/login.js
@@ -15,7 +15,7 @@ const styles = theme => ({
   ...theme.otherStyling
 });
 
-function Login({ classes, history }) {
+const Login = ({ classes, history }) => {
   const dispatch = useDispatch();
   const { email, password, isLoading, errors } = useSelector(state => ({
     ...state.user,
@@ -93,7 +93,7 @@ function Login({ classes, history }) {
       <Grid item sm />
     </Grid>
   );
-}
+};
 
 Login.propTypes = {
   classes: PropTypes.object.isRequired

--- a/amistad-client/src/pages/signup.js
+++ b/amistad-client/src/pages/signup.js
@@ -15,7 +15,7 @@ const styles = theme => ({
   ...theme.otherStyling
 });
 
-function Signup({ classes, history }) {
+const Signup = ({ classes, history }) => {
   const dispatch = useDispatch();
   const {
     email,
@@ -129,7 +129,7 @@ function Signup({ classes, history }) {
       <Grid item sm />
     </Grid>
   );
-}
+};
 
 Signup.propTypes = {
   classes: PropTypes.object.isRequired

--- a/amistad-client/src/redux/actions/userActions.js
+++ b/amistad-client/src/redux/actions/userActions.js
@@ -4,7 +4,8 @@ import {
   UPDATE_FORM_DATA,
   SET_ERRORS,
   SET_USER,
-  SET_UNAUTHENTICATED
+  SET_UNAUTHENTICATED,
+  LOADING_USER
 } from "../types";
 
 export const loginUser = async (dispatch, { email, password }, history) => {
@@ -92,6 +93,7 @@ export const updateFormData = (dispatch, target) => {
 
 export const getUserData = async dispatch => {
   try {
+    dispatch({ type: LOADING_USER });
     const { data } = await axios.get("/user");
     dispatch({ type: SET_USER, payload: data });
   } catch ({ response: { data } }) {

--- a/amistad-client/src/redux/reducers/userReducer.js
+++ b/amistad-client/src/redux/reducers/userReducer.js
@@ -1,7 +1,8 @@
-import { SET_USER, SET_AUTHENTICATED, SET_UNAUTHENTICATED } from "../types";
+import { SET_USER, SET_AUTHENTICATED, SET_UNAUTHENTICATED, LOADING_USER } from "../types";
 
 const initialState = {
   authenticated: false,
+  loading: false,
   credentials: {},
   likes: [],
   notifications: []
@@ -10,9 +11,11 @@ const initialState = {
 const userReducer = (state = initialState, { type, payload }) => {
   switch (type) {
     case SET_USER:
-      return { ...payload, authenticated: true };
+      return { ...payload, loading: false, authenticated: true };
     case SET_AUTHENTICATED:
       return { ...state, authenticated: true };
+    case LOADING_USER:
+      return { ...state, loading: true }
     case SET_UNAUTHENTICATED:
       return initialState;
     default:


### PR DESCRIPTION
## What does this PR do?
This PR implements the profile section of the homepage view

## What major activities were carried out?
- create profile component
- style profile component
- write code to conditionally render profile or gracefully degrade with options to login or signup

## How can this be manually tested?
- Clone the repository
- Fetch the branch
- Install the dependencies
- cd into the `amistad-client` folder
- Start project by running `npm start` in the terminal
- Your browser should automatically load to show you the homepage screen below:

![homepage with unlogged in user](https://user-images.githubusercontent.com/28527393/71559294-aa418580-2a5c-11ea-8a09-f67b82212de4.png)
- Click the `signup` button. You should see the following page:

![signup page](https://user-images.githubusercontent.com/28527393/71532515-fd4bf900-28f3-11ea-9fdf-6a60ad58ada6.png)

- Fill in the form details as appropriate, then submit. The browser should redirect to take you to the homepage with `screams`, showing you your profile card.

![logged in user with no profile picture](https://user-images.githubusercontent.com/28527393/71559375-5a16f300-2a5d-11ea-8bab-3271153a8c48.png)
