### PR TITLE
feat(profile): implement profile image upload

### DIFF
--- a/amistad-client/src/components/Profile.js
+++ b/amistad-client/src/components/Profile.js
@@ -1,15 +1,19 @@
 import React, { Fragment } from "react";
 import dayjs from "dayjs";
 import { Link } from "react-router-dom";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import withStyles from "@material-ui/core/styles/withStyles";
 import Paper from "@material-ui/core/Paper";
 import MuiLink from "@material-ui/core/Link";
 import Button from "@material-ui/core/Button";
+import IconButton from "@material-ui/core/IconButton";
+import EditIcon from "@material-ui/icons/Edit";
+import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
 import LocationOn from "@material-ui/icons/LocationOn";
 import LinkIcon from "@material-ui/icons/Link";
 import CalendarToday from "@material-ui/icons/CalendarToday";
+import { uploadProfileImage } from "../redux/actions/userActions";
 
 const styles = theme => ({
   paper: {
@@ -60,11 +64,24 @@ const styles = theme => ({
 });
 
 function Profile({ classes }) {
+  const dispatch = useDispatch();
   const {
     credentials: { handle, createdAt, imageUrl, bio, website, location },
     loading,
     authenticated
   } = useSelector(state => ({ ...state.user }));
+
+  const handleImageChange = ({ target: { files } }) => {
+    const [image] = files;
+    const formData = new FormData();
+    formData.append("image", image, image.name);
+    uploadProfileImage(dispatch, formData);
+  };
+
+  const handleEditPicture = () => {
+    const fileinput = document.getElementById("imageInput");
+    fileinput.click();
+  };
 
   return !loading ? (
     authenticated ? (
@@ -72,6 +89,17 @@ function Profile({ classes }) {
         <div className={classes.profile}>
           <div className="image-wrapper">
             <img src={imageUrl} alt="profile" className="profile-image" />
+            <input
+              type="file"
+              id="imageInput"
+              hidden="hidden"
+              onChange={handleImageChange}
+            />
+            <Tooltip title="Edit profile picture" placement="top">
+              <IconButton onClick={handleEditPicture} className="button">
+                <EditIcon color="primary" />
+              </IconButton>
+            </Tooltip>
           </div>
           <hr />
           <div className="profile-details">
@@ -139,7 +167,6 @@ function Profile({ classes }) {
   ) : (
     <p>Loading...</p>
   );
-  // return profileMarkup;
 }
 
 export default withStyles(styles)(Profile);

--- a/amistad-client/src/components/Scream.js
+++ b/amistad-client/src/components/Scream.js
@@ -1,16 +1,18 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import withStyles from '@material-ui/core/styles/withStyles';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardMedia from '@material-ui/core/CardMedia';
-import Typography from '@material-ui/core/Typography';
+import React from "react";
+import { Link } from "react-router-dom";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import withStyles from "@material-ui/core/styles/withStyles";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardMedia from "@material-ui/core/CardMedia";
+import Typography from "@material-ui/core/Typography";
+
+const endpoint = "https://us-central1-amistad-9f94a.cloudfunctions.net/api";
 
 const styles = {
   card: {
-    display: 'flex',
+    display: "flex",
     marginBottom: 20
   },
   content: {
@@ -18,9 +20,9 @@ const styles = {
   },
   image: {
     minWidth: 200,
-    objectFit: 'cover'
+    objectFit: "cover"
   }
-}
+};
 
 const Scream = ({
   classes,
@@ -37,14 +39,27 @@ const Scream = ({
   dayjs.extend(relativeTime);
   return (
     <Card className={classes.card}>
-      <CardMedia className={classes.image} image={userImage} title='Profile Image' />
+      <CardMedia
+        className={classes.image}
+        image={userImage}
+        title="Profile Image"
+      />
       <CardContent className={classes.content}>
-      <Typography variant='h5' color='primary' component={Link} to={`/users/${userHandle}`}>{userHandle}</Typography>
-      <Typography variant='body2' color='textSecondary'>{dayjs(createdAt).fromNow()}</Typography>
-      <Typography variant='body1'>{body}</Typography>
+        <Typography
+          variant="h5"
+          color="primary"
+          component={Link}
+          to={`${endpoint}/users/${userHandle}`}
+        >
+          {userHandle}
+        </Typography>
+        <Typography variant="body2" color="textSecondary">
+          {dayjs(createdAt).fromNow()}
+        </Typography>
+        <Typography variant="body1">{body}</Typography>
       </CardContent>
     </Card>
-  )
-}
+  );
+};
 
 export default withStyles(styles)(Scream);

--- a/amistad-client/src/pages/home.js
+++ b/amistad-client/src/pages/home.js
@@ -4,12 +4,14 @@ import Grid from "@material-ui/core/Grid";
 import Scream from "../components/Scream";
 import Profile from "../components/Profile";
 
+const endpoint = "https://us-central1-amistad-9f94a.cloudfunctions.net/api";
+
 const Home = () => {
   const [screams, setScream] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
-      const { data: screams } = await axios.get("/screams");
+      const { data: screams } = await axios.get(`${endpoint}/screams`);
       setScream(screams);
     };
     fetchData();

--- a/amistad-client/src/redux/actions/userActions.js
+++ b/amistad-client/src/redux/actions/userActions.js
@@ -8,12 +8,14 @@ import {
   LOADING_USER
 } from "../types";
 
+const endpoint = "https://us-central1-amistad-9f94a.cloudfunctions.net/api";
+
 export const loginUser = async (dispatch, { email, password }, history) => {
   try {
     dispatch({ type: SET_LOADING_STATUS, payload: { isLoading: true } });
     const {
       data: { token }
-    } = await axios.post("/login", {
+    } = await axios.post(`${endpoint}/login`, {
       email,
       password
     });
@@ -43,7 +45,7 @@ export const signupUser = async (
     dispatch({ type: SET_LOADING_STATUS, payload: { isLoading: true } });
     const {
       data: { token }
-    } = await axios.post("/signup", {
+    } = await axios.post(`${endpoint}/signup`, {
       email,
       password,
       confirmPassword,
@@ -94,9 +96,20 @@ export const updateFormData = (dispatch, target) => {
 export const getUserData = async dispatch => {
   try {
     dispatch({ type: LOADING_USER });
-    const { data } = await axios.get("/user");
+    const { data } = await axios.get(`${endpoint}/user`);
     dispatch({ type: SET_USER, payload: data });
   } catch ({ response: { data } }) {
     dispatch({ type: SET_ERRORS, payload: { errors: data } });
+  }
+};
+
+export const uploadProfileImage = async (dispatch, formData) => {
+  try {
+    dispatch({ type: LOADING_USER });
+    await axios.post(`${endpoint}/users/image`, formData);
+    await getUserData(dispatch);
+  } catch ({ response: { data } }) {
+    await getUserData(dispatch);
+    console.log(data);
   }
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,5 +1,8 @@
 const functions = require('firebase-functions');
 const app = require('express')();
+const cors = require('cors');
+
+app.use(cors());
 
 const FBAuth = require('./util/FBAuth');
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "busboy": "^0.3.1",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "firebase": "^6.5.0",
     "firebase-admin": "^8.0.0",


### PR DESCRIPTION
## What does this PR do?
This PR implements the edit profile image feature

## What major activities were carried out?
- create image upload input type and button
- write action to handle image upload from the UI

## How can this be manually tested?
- Clone the repository
- Fetch the branch
- Install the dependencies
- cd into the `amistad-client` folder
- Start project by running `npm start` in the terminal
- Your browser should automatically load to show you the homepage screen below:

![homepage with unlogged in user](https://user-images.githubusercontent.com/28527393/71559294-aa418580-2a5c-11ea-8a09-f67b82212de4.png)
- Click the `signup` button. You should see the following page:

![signup page](https://user-images.githubusercontent.com/28527393/71532515-fd4bf900-28f3-11ea-9fdf-6a60ad58ada6.png)

- Fill in the form details as appropriate, then submit. The browser should redirect to take you to the homepage with `screams`, showing you your profile card with the edit icon present.

![profile with edit picture icon](https://user-images.githubusercontent.com/28527393/71583353-5d1dec00-2b0e-11ea-8a45-75fc913e5f2d.png)
- Click on the `edit` icon, pick your image and the app should automatically upload it, and refresh your profile image.
.

