### PR TITLE
feat(profile): implement profile edit details

### DIFF
--- a/amistad-client/src/components/EditDetails.js
+++ b/amistad-client/src/components/EditDetails.js
@@ -1,0 +1,111 @@
+import React, { Fragment, useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import withStyles from "@material-ui/core/styles/withStyles";
+import { editUserDetails } from "../redux/actions/userActions";
+import Button from "@material-ui/core/Button";
+import IconButton from "@material-ui/core/IconButton";
+import EditIcon from "@material-ui/icons/Edit";
+import Tooltip from "@material-ui/core/Tooltip";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import TextField from "@material-ui/core/TextField";
+
+const styles = theme => ({
+  ...theme.otherStyling,
+  button: {
+    float: "right"
+  }
+});
+
+const EditDetails = ({ classes }) => {
+  const dispatch = useDispatch();
+  const { credentials } = useSelector(state => ({
+    ...state.user
+  }));
+
+  const [formDetails, setFormDetails] = useState({
+    bio: credentials.bio ? credentials.bio : "",
+    location: credentials.location ? credentials.location : "",
+    website: credentials.website ? credentials.website : ""
+  });
+
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleChange = ({ target: { name, value } }) => {
+    setFormDetails({ ...formDetails, [name]: value });
+  };
+
+  const handleSubmit = () => {
+    editUserDetails(dispatch, formDetails);
+    handleClose();
+  };
+
+  return (
+    <Fragment>
+      <Tooltip title="Edit details" placement="top">
+        <IconButton onClick={handleOpen} className={classes.button}>
+          <EditIcon color="primary" />
+        </IconButton>
+      </Tooltip>
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+        <DialogTitle>Edit your details</DialogTitle>
+        <DialogContent>
+          <form>
+            <TextField
+              type="text"
+              name="bio"
+              label="Bio"
+              multiline
+              rows="3"
+              fullWidth
+              className={classes.textField}
+              placeholder="A short bio about yourself"
+              value={formDetails.bio}
+              onChange={handleChange}
+            />
+            <TextField
+              type="text"
+              name="location"
+              label="Location"
+              fullWidth
+              className={classes.textField}
+              placeholder="Where you live"
+              value={formDetails.location}
+              onChange={handleChange}
+            />
+            <TextField
+              type="text"
+              name="website"
+              label="Website"
+              fullWidth
+              className={classes.textField}
+              placeholder="Your personal/professional website"
+              value={formDetails.website}
+              onChange={handleChange}
+            />
+          </form>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} color="primary">
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Fragment>
+  );
+};
+
+export default withStyles(styles)(EditDetails);

--- a/amistad-client/src/components/Profile.js
+++ b/amistad-client/src/components/Profile.js
@@ -8,12 +8,14 @@ import MuiLink from "@material-ui/core/Link";
 import Button from "@material-ui/core/Button";
 import IconButton from "@material-ui/core/IconButton";
 import EditIcon from "@material-ui/icons/Edit";
+import KeyboardReturn from "@material-ui/icons/KeyboardReturn";
 import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
 import LocationOn from "@material-ui/icons/LocationOn";
 import LinkIcon from "@material-ui/icons/Link";
 import CalendarToday from "@material-ui/icons/CalendarToday";
-import { uploadProfileImage } from "../redux/actions/userActions";
+import { logoutUser, uploadProfileImage } from "../redux/actions/userActions";
+import EditDetails from "./EditDetails";
 
 const styles = theme => ({
   paper: {
@@ -83,6 +85,10 @@ function Profile({ classes }) {
     fileinput.click();
   };
 
+  const handleLogout = () => {
+    logoutUser(dispatch);
+  };
+
   return !loading ? (
     authenticated ? (
       <Paper className={classes.paper}>
@@ -137,6 +143,12 @@ function Profile({ classes }) {
             <CalendarToday color="primary" />{" "}
             <span>Joined {dayjs(createdAt).format("MMM YYYY")}</span>
           </div>
+          <Tooltip title="Logout" placement="top">
+            <IconButton onClick={handleLogout}>
+              <KeyboardReturn color="primary" />
+            </IconButton>
+          </Tooltip>
+          <EditDetails />
         </div>
       </Paper>
     ) : (

--- a/amistad-client/src/redux/actions/userActions.js
+++ b/amistad-client/src/redux/actions/userActions.js
@@ -113,3 +113,14 @@ export const uploadProfileImage = async (dispatch, formData) => {
     console.log(data);
   }
 };
+
+export const editUserDetails = async (dispatch, userDetails) => {
+  try {
+    dispatch({ type: LOADING_USER });
+    await axios.post(`${endpoint}/user`, userDetails);
+    await getUserData(dispatch);
+  } catch ({ response: { data } }) {
+    console.log(data);
+    await getUserData(dispatch);
+  }
+};

--- a/amistad-client/src/redux/reducers/uiReducer.js
+++ b/amistad-client/src/redux/reducers/uiReducer.js
@@ -6,7 +6,10 @@ const initialState = {
   email: "",
   password: "",
   confirmPassword: "",
-  handle: ""
+  handle: "",
+  bio: "",
+  location: "",
+  website: ""
 };
 
 const uiReducer = (state = initialState, { type, payload }) => {

--- a/amistad-client/src/util/theme.js
+++ b/amistad-client/src/util/theme.js
@@ -1,16 +1,16 @@
 export default {
   palette: {
     primary: {
-      light: '#33c9dc',
-      dark: '#008394',
-      main: '#00bcd4',
-      contrastText: '#fff'
+      light: "#33c9dc",
+      dark: "#008394",
+      main: "#00bcd4",
+      contrastText: "#fff"
     },
     secondary: {
-      light: '#ff6333',
-      dark: '#ff3d00',
-      main: '#b22a00',
-      contrastText: '#fff'
+      light: "#ff6333",
+      dark: "#ff3d00",
+      main: "#b22a00",
+      contrastText: "#fff"
     }
   },
   otherStyling: {
@@ -18,29 +18,29 @@ export default {
       useNextVariants: true
     },
     form: {
-      textAlign: 'center'
+      textAlign: "center"
     },
     image: {
-      margin: '20px auto 0 auto',
-      width: '52px',
-      height: '52px'
+      margin: "20px auto 0 auto",
+      width: "52px",
+      height: "52px"
     },
     pageTitle: {
-      margin: '10px auto 10px auto',
+      margin: "10px auto 10px auto"
     },
     textField: {
-      margin: '10px auto 10px auto',
+      margin: "10px auto 10px auto"
     },
     button: {
       marginTop: 20,
-      position: 'relative'
+      position: "relative"
     },
     progress: {
-      position: 'absolute'
+      position: "absolute"
     },
     customError: {
-      color: 'red',
-      fontSize: '0.8rem',
+      color: "red",
+      fontSize: "0.8rem",
       marginTop: 10
     }
   }


### PR DESCRIPTION
## What does this PR do?
This PR implements the edit profile details and logout feature

## What major activities were carried out?
- create profile edit component
- create action to send edited details to server
- style component and add to profile card
- add logout button and style it
- write action to log user out of the system

## How can this be manually tested?
- Clone the repository
- Fetch the branch
- Install the dependencies
- cd into the `amistad-client` folder
- Start project by running `npm start` in the terminal
- Your browser should automatically load to show you the homepage screen below:

![homepage with unlogged in user](https://user-images.githubusercontent.com/28527393/71559294-aa418580-2a5c-11ea-8a09-f67b82212de4.png)
- Click the `signup` button. You should see the following page:

![signup page](https://user-images.githubusercontent.com/28527393/71532515-fd4bf900-28f3-11ea-9fdf-6a60ad58ada6.png)

- Fill in the form details as appropriate, then submit. The browser should redirect to take you to the homepage with `screams`, showing you your profile card with the profile edit icon present on the right, and the logout icon present on the left.

![profile edit homepage](https://user-images.githubusercontent.com/28527393/71654758-c29ef200-2d33-11ea-9ffb-e68970ee19bd.png)

- Click on the profile `edit` icon on the right, you should see the following image:

![edit profile details](https://user-images.githubusercontent.com/28527393/71654796-e8c49200-2d33-11ea-9758-26647daec063.png)

- Fill in the details and click `save`. It should automatically reload your peofile card with the updated details.
- Click the `logout` button on the left, and it should take you back to the homepage, asking you to either login or signup.