### PR TITLE
feat(screams): implement like and unlike features

### DIFF
--- a/amistad-client/src/App.css
+++ b/amistad-client/src/App.css
@@ -1,6 +1,7 @@
 html,
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   background-color: rgb(245, 245, 245);
 }
 .container {
@@ -9,6 +10,9 @@ body {
 }
 .nav-container {
   margin: auto;
+}
+.nav-container svg {
+  color: #fff;
 }
 a {
   text-decoration: none;

--- a/amistad-client/src/components/EditDetails.js
+++ b/amistad-client/src/components/EditDetails.js
@@ -3,9 +3,8 @@ import { useSelector, useDispatch } from "react-redux";
 import withStyles from "@material-ui/core/styles/withStyles";
 import { editUserDetails } from "../redux/actions/userActions";
 import Button from "@material-ui/core/Button";
-import IconButton from "@material-ui/core/IconButton";
+import MyButton from "../util/myButton";
 import EditIcon from "@material-ui/icons/Edit";
-import Tooltip from "@material-ui/core/Tooltip";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
@@ -52,11 +51,13 @@ const EditDetails = ({ classes }) => {
 
   return (
     <Fragment>
-      <Tooltip title="Edit details" placement="top">
-        <IconButton onClick={handleOpen} className={classes.button}>
-          <EditIcon color="primary" />
-        </IconButton>
-      </Tooltip>
+      <MyButton
+        tip="Edit details"
+        onClick={handleOpen}
+        btnClassName={classes.button}
+      >
+        <EditIcon color="primary" />
+      </MyButton>
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
         <DialogTitle>Edit your details</DialogTitle>
         <DialogContent>

--- a/amistad-client/src/components/Navbar.js
+++ b/amistad-client/src/components/Navbar.js
@@ -1,22 +1,56 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { Fragment } from "react";
+import { Link } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import Button from '@material-ui/core/Button';
+import MyButton from "../util/myButton";
+
+import AppBar from "@material-ui/core/AppBar";
+import Toolbar from "@material-ui/core/Toolbar";
+import Button from "@material-ui/core/Button";
+
+import AddIcon from "@material-ui/icons/Add";
+import HomeIcon from "@material-ui/icons/Home";
+import Notifications from "@material-ui/icons/Notifications";
 
 const Navbar = () => {
+  const { authenticated } = useSelector(state => ({
+    ...state.user
+  }));
   return (
     <div>
       <AppBar>
         <Toolbar className="nav-container">
-          <Button color="inherit" component={Link} to="/">Home</Button>
-          <Button color="inherit" component={Link} to="/signup">Signup</Button>
-          <Button color="inherit" component={Link} to="/login">Login</Button>
+          {authenticated ? (
+            <Fragment>
+              <MyButton tip="Post a Scream!">
+                <AddIcon />
+              </MyButton>
+              <Link to="/">
+                <MyButton tip="Home">
+                  <HomeIcon />
+                </MyButton>
+              </Link>
+              <MyButton tip="Notifications">
+                <Notifications />
+              </MyButton>
+            </Fragment>
+          ) : (
+            <Fragment>
+              <Button color="inherit" component={Link} to="/">
+                Home
+              </Button>
+              <Button color="inherit" component={Link} to="/signup">
+                Signup
+              </Button>
+              <Button color="inherit" component={Link} to="/login">
+                Login
+              </Button>
+            </Fragment>
+          )}
         </Toolbar>
       </AppBar>
     </div>
-  )
-}
+  );
+};
 
 export default Navbar;

--- a/amistad-client/src/components/Profile.js
+++ b/amistad-client/src/components/Profile.js
@@ -6,16 +6,15 @@ import withStyles from "@material-ui/core/styles/withStyles";
 import Paper from "@material-ui/core/Paper";
 import MuiLink from "@material-ui/core/Link";
 import Button from "@material-ui/core/Button";
-import IconButton from "@material-ui/core/IconButton";
 import EditIcon from "@material-ui/icons/Edit";
 import KeyboardReturn from "@material-ui/icons/KeyboardReturn";
-import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
 import LocationOn from "@material-ui/icons/LocationOn";
 import LinkIcon from "@material-ui/icons/Link";
 import CalendarToday from "@material-ui/icons/CalendarToday";
 import { logoutUser, uploadProfileImage } from "../redux/actions/userActions";
 import EditDetails from "./EditDetails";
+import MyButton from "../util/myButton";
 
 const styles = theme => ({
   paper: {
@@ -101,11 +100,13 @@ function Profile({ classes }) {
               hidden="hidden"
               onChange={handleImageChange}
             />
-            <Tooltip title="Edit profile picture" placement="top">
-              <IconButton onClick={handleEditPicture} className="button">
-                <EditIcon color="primary" />
-              </IconButton>
-            </Tooltip>
+            <MyButton
+              tip="Edit profile picture"
+              onClick={handleEditPicture}
+              btnClassName="button"
+            >
+              <EditIcon color="primary" />
+            </MyButton>
           </div>
           <hr />
           <div className="profile-details">
@@ -143,11 +144,9 @@ function Profile({ classes }) {
             <CalendarToday color="primary" />{" "}
             <span>Joined {dayjs(createdAt).format("MMM YYYY")}</span>
           </div>
-          <Tooltip title="Logout" placement="top">
-            <IconButton onClick={handleLogout}>
-              <KeyboardReturn color="primary" />
-            </IconButton>
-          </Tooltip>
+          <MyButton tip="Logout" onClick={handleLogout}>
+            <KeyboardReturn color="primary" />
+          </MyButton>
           <EditDetails />
         </div>
       </Paper>

--- a/amistad-client/src/components/Scream.js
+++ b/amistad-client/src/components/Scream.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import withStyles from "@material-ui/core/styles/withStyles";
@@ -7,8 +8,12 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
 import Typography from "@material-ui/core/Typography";
+import ChatIcon from "@material-ui/icons/Chat";
+import FavoriteIcon from "@material-ui/icons/Favorite";
+import FavoriteBorder from "@material-ui/icons/FavoriteBorder";
 
-const endpoint = "https://us-central1-amistad-9f94a.cloudfunctions.net/api";
+import MyButton from "../util/myButton";
+import { likeScream, unlikeScream } from "../redux/actions/dataActions";
 
 const styles = {
   card: {
@@ -36,20 +41,47 @@ const Scream = ({
     screamId
   }
 }) => {
+  const { likes, authenticated } = useSelector(state => ({ ...state.user }));
+  const dispatch = useDispatch();
+
+  // check if logged in user likes this scream
+  const likedScream =
+    likes && likes.find(like => like.screamId === screamId) ? true : false;
+
+  const doLikeScream = () => likeScream(dispatch, screamId);
+  const doUnlikeScream = () => unlikeScream(dispatch, screamId);
+
+  const likeButton = !authenticated ? (
+    <MyButton tip="Like">
+      <Link to="/login">
+        <FavoriteBorder color="primary" />
+      </Link>
+    </MyButton>
+  ) : !likedScream ? (
+    <MyButton tip="Like" onClick={doLikeScream}>
+      <FavoriteBorder color="primary" />
+    </MyButton>
+  ) : (
+    <MyButton tip="Unlike" onClick={doUnlikeScream}>
+      <FavoriteIcon color="primary" />
+    </MyButton>
+  );
   dayjs.extend(relativeTime);
   return (
     <Card className={classes.card}>
       <CardMedia
         className={classes.image}
         image={userImage}
-        title="Profile Image"
+        title={userHandle}
+        component={Link}
+        to={`/users/${userHandle}`}
       />
       <CardContent className={classes.content}>
         <Typography
           variant="h5"
           color="primary"
           component={Link}
-          to={`${endpoint}/users/${userHandle}`}
+          to={`/users/${userHandle}`}
         >
           {userHandle}
         </Typography>
@@ -57,6 +89,12 @@ const Scream = ({
           {dayjs(createdAt).fromNow()}
         </Typography>
         <Typography variant="body1">{body}</Typography>
+        {likeButton}
+        <span>{likeCount} likes</span>
+        <MyButton tip="comments">
+          <ChatIcon color="primary" />
+        </MyButton>
+        <span>{commentCount} comments</span>
       </CardContent>
     </Card>
   );

--- a/amistad-client/src/pages/home.js
+++ b/amistad-client/src/pages/home.js
@@ -1,27 +1,28 @@
-import React, { useState, useEffect } from "react";
-import axios from "axios";
+import React, { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import Grid from "@material-ui/core/Grid";
 import Scream from "../components/Scream";
 import Profile from "../components/Profile";
-
-const endpoint = "https://us-central1-amistad-9f94a.cloudfunctions.net/api";
+import { getScreams } from "../redux/actions/dataActions";
 
 const Home = () => {
-  const [screams, setScream] = useState([]);
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    const fetchData = async () => {
-      const { data: screams } = await axios.get(`${endpoint}/screams`);
-      setScream(screams);
-    };
-    fetchData();
+    getScreams(dispatch);
   }, []);
-  const recentScreamsMarkup =
-    screams.length > 0 ? (
-      screams.map(scream => <Scream key={scream.screamId} scream={scream} />)
-    ) : (
-      <p>Loading...</p>
-    );
+
+  const { screams, loading } = useSelector(state => ({
+    ...state.data,
+    ...state.ui,
+    ...state.user
+  }));
+  const recentScreamsMarkup = !loading ? (
+    screams.map(scream => <Scream key={scream.screamId} scream={scream} />)
+  ) : (
+    <p>Loading...</p>
+  );
+
   return (
     <Grid container spacing={2}>
       <Grid item sm={8} xs={12}>

--- a/amistad-client/src/redux/actions/dataActions.js
+++ b/amistad-client/src/redux/actions/dataActions.js
@@ -1,0 +1,38 @@
+import {
+  SET_SCREAMS,
+  LOADING_DATA,
+  UNLIKE_SCREAM,
+  LIKE_SCREAM
+} from "../types";
+import axios from "axios";
+import api from "../../util/api";
+
+export const getScreams = async dispatch => {
+  try {
+    dispatch({ type: LOADING_DATA });
+    const { data: screams } = await axios.get(api.screams);
+    dispatch({ type: SET_SCREAMS, payload: screams });
+  } catch ({ response: { data } }) {
+    console.log(data);
+    dispatch({ type: SET_SCREAMS, payload: [] });
+  }
+};
+
+export const likeScream = async (dispatch, screamId) => {
+  try {
+    const { data: scream } = await axios.get(`${api.screams}/${screamId}/like`);
+    dispatch({ type: LIKE_SCREAM, payload: scream });
+  } catch ({ response: { data } }) {
+    console.log(data);
+  }
+};
+export const unlikeScream = async (dispatch, screamId) => {
+  try {
+    const { data: scream } = await axios.get(
+      `${api.screams}/${screamId}/unlike`
+    );
+    dispatch({ type: UNLIKE_SCREAM, payload: scream });
+  } catch ({ response: { data } }) {
+    console.log(data);
+  }
+};

--- a/amistad-client/src/redux/actions/userActions.js
+++ b/amistad-client/src/redux/actions/userActions.js
@@ -7,15 +7,14 @@ import {
   SET_UNAUTHENTICATED,
   LOADING_USER
 } from "../types";
-
-const endpoint = "https://us-central1-amistad-9f94a.cloudfunctions.net/api";
+import api from "../../util/api";
 
 export const loginUser = async (dispatch, { email, password }, history) => {
   try {
     dispatch({ type: SET_LOADING_STATUS, payload: { isLoading: true } });
     const {
       data: { token }
-    } = await axios.post(`${endpoint}/login`, {
+    } = await axios.post(api.login, {
       email,
       password
     });
@@ -45,7 +44,7 @@ export const signupUser = async (
     dispatch({ type: SET_LOADING_STATUS, payload: { isLoading: true } });
     const {
       data: { token }
-    } = await axios.post(`${endpoint}/signup`, {
+    } = await axios.post(api.signup, {
       email,
       password,
       confirmPassword,
@@ -89,6 +88,7 @@ export const logoutUser = dispatch => {
   delete axios.defaults.headers.common["Authorization"];
   dispatch({ type: SET_UNAUTHENTICATED });
 };
+
 export const updateFormData = (dispatch, target) => {
   dispatch({ type: UPDATE_FORM_DATA, payload: target });
 };
@@ -96,7 +96,7 @@ export const updateFormData = (dispatch, target) => {
 export const getUserData = async dispatch => {
   try {
     dispatch({ type: LOADING_USER });
-    const { data } = await axios.get(`${endpoint}/user`);
+    const { data } = await axios.get(api.user);
     dispatch({ type: SET_USER, payload: data });
   } catch ({ response: { data } }) {
     dispatch({ type: SET_ERRORS, payload: { errors: data } });
@@ -106,7 +106,7 @@ export const getUserData = async dispatch => {
 export const uploadProfileImage = async (dispatch, formData) => {
   try {
     dispatch({ type: LOADING_USER });
-    await axios.post(`${endpoint}/users/image`, formData);
+    await axios.post(api.image, formData);
     await getUserData(dispatch);
   } catch ({ response: { data } }) {
     await getUserData(dispatch);
@@ -117,7 +117,7 @@ export const uploadProfileImage = async (dispatch, formData) => {
 export const editUserDetails = async (dispatch, userDetails) => {
   try {
     dispatch({ type: LOADING_USER });
-    await axios.post(`${endpoint}/user`, userDetails);
+    await axios.post(api.user, userDetails);
     await getUserData(dispatch);
   } catch ({ response: { data } }) {
     console.log(data);

--- a/amistad-client/src/redux/reducers/dataReducer.js
+++ b/amistad-client/src/redux/reducers/dataReducer.js
@@ -1,0 +1,32 @@
+import {
+  SET_SCREAMS,
+  LOADING_DATA,
+  UNLIKE_SCREAM,
+  LIKE_SCREAM
+} from "../types";
+
+const initialState = {
+  screams: [],
+  scream: {},
+  loading: false
+};
+
+const dataReducer = (state = initialState, { type, payload }) => {
+  switch (type) {
+    case LOADING_DATA:
+      return { ...state, loading: true };
+    case SET_SCREAMS:
+      return { ...state, screams: payload, loading: false };
+    case LIKE_SCREAM:
+    case UNLIKE_SCREAM:
+      let index = state.screams.findIndex(
+        scream => scream.screamId === payload.screamId
+      );
+      state.screams[index] = payload;
+      return { ...state };
+    default:
+      return { ...state };
+  }
+};
+
+export default dataReducer;

--- a/amistad-client/src/redux/reducers/uiReducer.js
+++ b/amistad-client/src/redux/reducers/uiReducer.js
@@ -6,10 +6,7 @@ const initialState = {
   email: "",
   password: "",
   confirmPassword: "",
-  handle: "",
-  bio: "",
-  location: "",
-  website: ""
+  handle: ""
 };
 
 const uiReducer = (state = initialState, { type, payload }) => {

--- a/amistad-client/src/redux/reducers/userReducer.js
+++ b/amistad-client/src/redux/reducers/userReducer.js
@@ -1,4 +1,11 @@
-import { SET_USER, SET_AUTHENTICATED, SET_UNAUTHENTICATED, LOADING_USER } from "../types";
+import {
+  SET_USER,
+  SET_AUTHENTICATED,
+  SET_UNAUTHENTICATED,
+  LOADING_USER,
+  LIKE_SCREAM,
+  UNLIKE_SCREAM
+} from "../types";
 
 const initialState = {
   authenticated: false,
@@ -15,9 +22,22 @@ const userReducer = (state = initialState, { type, payload }) => {
     case SET_AUTHENTICATED:
       return { ...state, authenticated: true };
     case LOADING_USER:
-      return { ...state, loading: true }
+      return { ...state, loading: true };
     case SET_UNAUTHENTICATED:
       return initialState;
+    case LIKE_SCREAM:
+      return {
+        ...state,
+        likes: [
+          ...state.likes,
+          { userHandle: state.credentials.handle, screamId: payload.screamId }
+        ]
+      };
+    case UNLIKE_SCREAM:
+      return {
+        ...state,
+        likes: state.likes.filter(like => like.screamId !== payload.screamId)
+      };
     default:
       return { ...state };
   }

--- a/amistad-client/src/redux/types.js
+++ b/amistad-client/src/redux/types.js
@@ -5,3 +5,7 @@ export const LOADING_USER = "LOADING_USER";
 export const UPDATE_FORM_DATA = "UPDATE_FORM_DATA";
 export const SET_LOADING_STATUS = "SET_LOADING_STATUS";
 export const SET_ERRORS = "SET_ERRORS";
+export const SET_SCREAMS = "SET_SCREAMS";
+export const LOADING_DATA = "LOADING_DATA";
+export const LIKE_SCREAM = "LIKE_SCREAM";
+export const UNLIKE_SCREAM = "UNLIKE_SCREAM";

--- a/amistad-client/src/util/api.js
+++ b/amistad-client/src/util/api.js
@@ -1,0 +1,9 @@
+const endpoint = "https://us-central1-amistad-9f94a.cloudfunctions.net/api";
+
+export default {
+  login: `${endpoint}/login`,
+  signup: `${endpoint}/signup`,
+  screams: `${endpoint}/screams`,
+  user: `${endpoint}/user`,
+  image: `${endpoint}/users/image`
+};

--- a/amistad-client/src/util/myButton.js
+++ b/amistad-client/src/util/myButton.js
@@ -1,0 +1,11 @@
+import React from "react";
+import Tooltip from "@material-ui/core/Tooltip";
+import IconButton from "@material-ui/core/IconButton";
+
+export default ({ children, tip, btnClassName, onClick, tipClassName }) => (
+  <Tooltip title={tip} className={tipClassName}>
+    <IconButton onClick={onClick} className={btnClassName}>
+      {children}
+    </IconButton>
+  </Tooltip>
+);


### PR DESCRIPTION
## What does this PR do?
This PR implements the like and unlike UI functionality

## What major activities were carried out?
- create navbar buttons for `home`, `post scream`, and `notifications` for authenticated user
- create `like` and `unlike` buttons for screams
- write data action functions to handle clicking `like` and `unlike` on screams
- write reducers to handle the actions dispatched by liking and unliking screams

## How can this be manually tested?
- Clone the repository
- Fetch the branch
- Install the dependencies
- cd into the `amistad-client` folder
- Start project by running `npm start` in the terminal
- Your browser should automatically load to show you the homepage screen below:

![homepage with like and comments button](https://user-images.githubusercontent.com/28527393/71725010-b5b4f800-2e32-11ea-90eb-468b9ff89616.png)
- Click the `signup` button. You should see the following page:

![signup page](https://user-images.githubusercontent.com/28527393/71532515-fd4bf900-28f3-11ea-9fdf-6a60ad58ada6.png)

- Fill in the form details as appropriate, then submit. The browser should redirect to take you to the homepage with `screams`, showing the `like` and `comments` button on each scream, and the `number of likes/comments` besides each button

![authenticated with like and comment button](https://user-images.githubusercontent.com/28527393/71724984-a03fce00-2e32-11ea-97bb-ea49f9d59a82.png)

- Click on the `like` button for any of it scream, and the number of likes should increase by one and the  icon become filled like this:

![authenticated with like button clicked](https://user-images.githubusercontent.com/28527393/71725054-e137e280-2e32-11ea-876e-63715bb6c7ae.png)
- Click on the `like` button of the same scream the second time, and the icon should become unfilled again with the number of likes decreased by one.