### PR TITLE
feat(scream): implement view scream UI

### DIFF
--- a/amistad-client/src/MyApp.js
+++ b/amistad-client/src/MyApp.js
@@ -12,7 +12,7 @@ import { SET_AUTHENTICATED } from "./redux/types";
 import { logoutUser, getUserData } from "./redux/actions/userActions";
 
 //Components
-import Navbar from "./components/Navbar";
+import Navbar from "./components/layout/Navbar";
 // Pages
 import home from "./pages/home";
 import signup from "./pages/signup";

--- a/amistad-client/src/components/layout/Navbar.js
+++ b/amistad-client/src/components/layout/Navbar.js
@@ -2,8 +2,8 @@ import React, { Fragment } from "react";
 import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
 
-import MyButton from "../util/myButton";
-import PostScream from "./PostScream";
+import MyButton from "../../util/myButton";
+import PostScream from "../scream/PostScream";
 
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";

--- a/amistad-client/src/components/profile/EditDetails.js
+++ b/amistad-client/src/components/profile/EditDetails.js
@@ -1,16 +1,16 @@
 import React, { Fragment, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import withStyles from "@material-ui/core/styles/withStyles";
-import { editUserDetails } from "../redux/actions/userActions";
+import { editUserDetails } from "../../redux/actions/userActions";
 import Button from "@material-ui/core/Button";
-import MyButton from "../util/myButton";
+import MyButton from "../../util/myButton";
 import EditIcon from "@material-ui/icons/Edit";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import TextField from "@material-ui/core/TextField";
-import { SET_DIALOG_STATUS } from "../redux/types";
+import { SET_DIALOG_STATUS } from "../../redux/types";
 
 const styles = theme => ({
   ...theme.otherStyling,

--- a/amistad-client/src/components/profile/Profile.js
+++ b/amistad-client/src/components/profile/Profile.js
@@ -12,9 +12,9 @@ import Typography from "@material-ui/core/Typography";
 import LocationOn from "@material-ui/icons/LocationOn";
 import LinkIcon from "@material-ui/icons/Link";
 import CalendarToday from "@material-ui/icons/CalendarToday";
-import { logoutUser, uploadProfileImage } from "../redux/actions/userActions";
+import { logoutUser, uploadProfileImage } from "../../redux/actions/userActions";
 import EditDetails from "./EditDetails";
-import MyButton from "../util/myButton";
+import MyButton from "../../util/myButton";
 
 const styles = theme => ({
   paper: {

--- a/amistad-client/src/components/scream/Comments.js
+++ b/amistad-client/src/components/scream/Comments.js
@@ -1,0 +1,65 @@
+import React, { Fragment } from "react";
+import withStyles from "@material-ui/core/styles/withStyles";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
+import { Link } from "react-router-dom";
+import dayjs from "dayjs";
+
+const styles = theme => ({
+  ...theme.otherStyling,
+  commentImage: {
+    width: "100%",
+    height: 100,
+    objectFit: "cover",
+    borderRadius: "50%"
+  },
+  commentData: {
+    marginLeft: 20
+  }
+});
+
+const Comments = ({ classes, comments }) => {
+  return (
+    <Grid container>
+      {comments.map(({ body, createdAt, userImage, userHandle }, index) => {
+        return (
+          <Fragment key={createdAt}>
+            <Grid item sm={12}>
+              <Grid container>
+                <Grid item sm={2}>
+                  <img
+                    src={userImage}
+                    className={classes.commentImage}
+                    alt={userHandle}
+                  />
+                </Grid>
+                <Grid item sm={9}>
+                  <div className={classes.commentData}>
+                    <Typography
+                      variant="h5"
+                      component={Link}
+                      to={`/users/${userHandle}`}
+                      color="primary"
+                    >
+                      {userHandle}
+                    </Typography>
+                    <Typography variant="body2" color="textSecondary">
+                      {dayjs(createdAt).format(`h:mm a, MMMM DD YYYY`)}
+                    </Typography>
+                    <hr className={classes.hiddenRule} />
+                    <Typography variant="body1">{body}</Typography>
+                  </div>
+                </Grid>
+              </Grid>
+            </Grid>
+            {index !== comments.length - 1 && (
+              <hr className={classes.visibleRule} />
+            )}
+          </Fragment>
+        );
+      })}
+    </Grid>
+  );
+};
+
+export default withStyles(styles)(Comments);

--- a/amistad-client/src/components/scream/DeleteScream.js
+++ b/amistad-client/src/components/scream/DeleteScream.js
@@ -2,12 +2,12 @@ import React, { Fragment, useState } from "react";
 import { useDispatch } from "react-redux";
 import withStyles from "@material-ui/core/styles/withStyles";
 import Button from "@material-ui/core/Button";
-import MyButton from "../util/myButton";
+import MyButton from "../../util/myButton";
 import DeleteOutline from "@material-ui/icons/DeleteOutline";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogTitle from "@material-ui/core/DialogTitle";
-import { deleteScream } from "../redux/actions/dataActions";
+import { deleteScream } from "../../redux/actions/dataActions";
 
 const styles = {
   deleteButton: {

--- a/amistad-client/src/components/scream/LikeButton.js
+++ b/amistad-client/src/components/scream/LikeButton.js
@@ -1,0 +1,38 @@
+import React from "react";
+import FavoriteIcon from "@material-ui/icons/Favorite";
+import FavoriteBorder from "@material-ui/icons/FavoriteBorder";
+import { Link } from "react-router-dom";
+import MyButton from "../../util/myButton";
+import { likeScream, unlikeScream } from "../../redux/actions/dataActions";
+import { useSelector, useDispatch } from "react-redux";
+
+const LikeButton = ({ screamId }) => {
+  const { likes, authenticated } = useSelector(state => ({ ...state.user }));
+
+  const dispatch = useDispatch();
+  // check if logged in user likes this scream
+  const likedScream =
+    likes && likes.find(like => like.screamId === screamId) ? true : false;
+
+  const doLikeScream = () => likeScream(dispatch, screamId);
+  const doUnlikeScream = () => unlikeScream(dispatch, screamId);
+
+  const likeButton = !authenticated ? (
+    <Link to="/login">
+      <MyButton tip="Like">
+        <FavoriteBorder color="primary" />
+      </MyButton>
+    </Link>
+  ) : !likedScream ? (
+    <MyButton tip="Like" onClick={doLikeScream}>
+      <FavoriteBorder color="primary" />
+    </MyButton>
+  ) : (
+    <MyButton tip="Unlike" onClick={doUnlikeScream}>
+      <FavoriteIcon color="primary" />
+    </MyButton>
+  );
+  return likeButton;
+};
+
+export default LikeButton;

--- a/amistad-client/src/components/scream/PostScream.js
+++ b/amistad-client/src/components/scream/PostScream.js
@@ -1,9 +1,9 @@
 import React, { Fragment, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import withStyles from "@material-ui/core/styles/withStyles";
-import { postScream } from "../redux/actions/dataActions";
+import { postScream } from "../../redux/actions/dataActions";
 import Button from "@material-ui/core/Button";
-import MyButton from "../util/myButton";
+import MyButton from "../../util/myButton";
 import AddIcon from "@material-ui/icons/Add";
 import CloseIcon from "@material-ui/icons/Close";
 import Dialog from "@material-ui/core/Dialog";
@@ -16,7 +16,8 @@ const styles = theme => ({
   ...theme.otherStyling,
   submitButton: {
     position: "relative",
-    float: "right"
+    float: "right",
+    marginTop: "10%"
   },
   closeButton: {
     position: "absolute",

--- a/amistad-client/src/components/scream/Scream.js
+++ b/amistad-client/src/components/scream/Scream.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import withStyles from "@material-ui/core/styles/withStyles";
@@ -9,12 +9,10 @@ import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
 import Typography from "@material-ui/core/Typography";
 import ChatIcon from "@material-ui/icons/Chat";
-import FavoriteIcon from "@material-ui/icons/Favorite";
-import FavoriteBorder from "@material-ui/icons/FavoriteBorder";
-
-import MyButton from "../util/myButton";
+import ScreamDialog from "./ScreamDialog";
+import LikeButton from "./LikeButton";
+import MyButton from "../../util/myButton";
 import DeleteScream from "./DeleteScream";
-import { likeScream, unlikeScream } from "../redux/actions/dataActions";
 
 const styles = {
   card: {
@@ -44,34 +42,10 @@ const Scream = ({
   }
 }) => {
   const {
-    likes,
     authenticated,
     credentials: { handle }
   } = useSelector(state => ({ ...state.user }));
-  const dispatch = useDispatch();
 
-  // check if logged in user likes this scream
-  const likedScream =
-    likes && likes.find(like => like.screamId === screamId) ? true : false;
-
-  const doLikeScream = () => likeScream(dispatch, screamId);
-  const doUnlikeScream = () => unlikeScream(dispatch, screamId);
-
-  const likeButton = !authenticated ? (
-    <MyButton tip="Like">
-      <Link to="/login">
-        <FavoriteBorder color="primary" />
-      </Link>
-    </MyButton>
-  ) : !likedScream ? (
-    <MyButton tip="Like" onClick={doLikeScream}>
-      <FavoriteBorder color="primary" />
-    </MyButton>
-  ) : (
-    <MyButton tip="Unlike" onClick={doUnlikeScream}>
-      <FavoriteIcon color="primary" />
-    </MyButton>
-  );
   const deleteButton =
     authenticated && userHandle === handle ? (
       <DeleteScream screamId={screamId} />
@@ -100,12 +74,13 @@ const Scream = ({
           {dayjs(createdAt).fromNow()}
         </Typography>
         <Typography variant="body1">{body}</Typography>
-        {likeButton}
+        <LikeButton screamId={screamId} />
         <span>{likeCount} likes</span>
         <MyButton tip="comments">
           <ChatIcon color="primary" />
         </MyButton>
         <span>{commentCount} comments</span>
+        <ScreamDialog screamId={screamId} userHandle={userHandle} />
       </CardContent>
     </Card>
   );

--- a/amistad-client/src/components/scream/ScreamDialog.js
+++ b/amistad-client/src/components/scream/ScreamDialog.js
@@ -1,0 +1,142 @@
+import React, { Fragment, useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import dayjs from "dayjs";
+import withStyles from "@material-ui/core/styles/withStyles";
+import { getSingleScream } from "../../redux/actions/dataActions";
+import ChatIcon from "@material-ui/icons/Chat";
+import LikeButton from "./LikeButton";
+import Comments from "./Comments";
+import MyButton from "../../util/myButton";
+import Dialog from "@material-ui/core/Dialog";
+import { Link } from "react-router-dom";
+import DialogContent from "@material-ui/core/DialogContent";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@material-ui/core/Grid";
+import CloseIcon from "@material-ui/icons/Close";
+import UnfoldMore from "@material-ui/icons/UnfoldMore";
+import CircularProgress from "@material-ui/core/CircularProgress";
+
+const styles = theme => {
+  return {
+    ...theme.otherStyling,
+    profileImage: {
+      maxWidth: 200,
+      height: 200,
+      borderRadius: "50%",
+      objectFir: "cover"
+    },
+    screamContent: {
+      padding: 20
+    },
+    closeButton: {
+      position: "absolute",
+      top: "5%",
+      left: "90%"
+    },
+    expandButton: {
+      position: "absolute",
+      left: "90%"
+    },
+    spinnerDiv: {
+      textAlign: "center",
+      maeginBottom: 50,
+      marginTop: 50
+    }
+  };
+};
+
+const ScreamDialog = ({ classes, screamId }) => {
+  const {
+    scream: {
+      body,
+      createdAt,
+      userImage,
+      likeCount,
+      commentCount,
+      userHandle,
+      comments
+    },
+    isLoading
+  } = useSelector(state => ({ ...state.data, ...state.ui }));
+  const [open, setOpen] = useState(false);
+  const dispatch = useDispatch();
+
+  const handleOpen = () => {
+    setOpen(true);
+    getSingleScream(dispatch, screamId);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const expandedScream = isLoading ? (
+    <div className={classes.spinnerDiv}>
+      <CircularProgress size={200} thickness={2} />
+    </div>
+  ) : (
+    <Grid container spacing={2}>
+      <Grid item sm={5}>
+        <img
+          src={userImage}
+          alt={userHandle}
+          className={classes.profileImage}
+        />
+      </Grid>
+      <Grid item sm={7}>
+        <Typography
+          component={Link}
+          color="primary"
+          to={`/users/${userHandle}`}
+          variant="h5"
+        >
+          @{userHandle}
+        </Typography>
+        <hr className={classes.hiddenRule} />
+        <Typography variant="body2" color="textSecondary">
+          {dayjs(createdAt).format(`h:mm a, MMMM DD YYYY`)}
+        </Typography>
+        <hr className={classes.hiddenRule} />
+        <Typography variant="body1">{body}</Typography>
+        <LikeButton screamId={screamId} />
+        <span>{likeCount} likes</span>
+        <MyButton tip="comments">
+          <ChatIcon color="primary" />
+        </MyButton>
+        <span>{commentCount} comments</span>
+      </Grid>
+      <hr
+        className={
+          commentCount === 0 ? classes.hiddenRule : classes.visibleRule
+        }
+      />
+      <Comments comments={comments} />
+    </Grid>
+  );
+
+  return (
+    <Fragment>
+      <MyButton
+        tip="Expand scream"
+        tipClassName={classes.expandButton}
+        onClick={handleOpen}
+      >
+        <UnfoldMore color="primary" />
+      </MyButton>
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+        <MyButton
+          tip="Close"
+          onClick={handleClose}
+          tipClassName={classes.closeButton}
+        >
+          <CloseIcon />
+        </MyButton>
+        <DialogContent className={classes.screamContent}>
+          {expandedScream}
+        </DialogContent>
+      </Dialog>
+    </Fragment>
+  );
+};
+
+export default withStyles(styles)(ScreamDialog);

--- a/amistad-client/src/pages/home.js
+++ b/amistad-client/src/pages/home.js
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import Grid from "@material-ui/core/Grid";
-import Scream from "../components/Scream";
-import Profile from "../components/Profile";
+import Scream from "../components/scream/Scream";
+import Profile from "../components/profile/Profile";
 import { getScreams } from "../redux/actions/dataActions";
 
 const Home = () => {

--- a/amistad-client/src/redux/actions/dataActions.js
+++ b/amistad-client/src/redux/actions/dataActions.js
@@ -1,5 +1,6 @@
 import {
   SET_SCREAMS,
+  SET_SINGLE_SCREAM,
   SET_ERRORS,
   SET_LOADING_STATUS,
   POST_SCREAM,
@@ -34,6 +35,18 @@ export const postScream = async (dispatch, newScream) => {
   }
 };
 
+export const getSingleScream = async (dispatch, screamId) => {
+  try {
+    dispatch({ type: SET_LOADING_STATUS, payload: { isLoading: true } });
+    const { data: scream } = await axios.get(`${api.screams}/${screamId}`);
+    console.log(scream);
+    dispatch({ type: SET_SINGLE_SCREAM, payload: scream });
+    dispatch({ type: SET_LOADING_STATUS, payload: { isLoading: false } });
+  } catch ({ response: { data } }) {
+    console.log(data);
+  }
+};
+
 export const likeScream = async (dispatch, screamId) => {
   try {
     const { data: scream } = await axios.get(`${api.screams}/${screamId}/like`);
@@ -56,9 +69,7 @@ export const unlikeScream = async (dispatch, screamId) => {
 
 export const deleteScream = async (dispatch, screamId) => {
   try {
-    const {
-      data: { message }
-    } = await axios.delete(`${api.screams}/${screamId}`);
+    await axios.delete(`${api.screams}/${screamId}`);
     dispatch({ type: DELETE_SCREAM, payload: { screamId } });
   } catch (error) {
     console.log(error);

--- a/amistad-client/src/redux/reducers/dataReducer.js
+++ b/amistad-client/src/redux/reducers/dataReducer.js
@@ -1,5 +1,6 @@
 import {
   SET_SCREAMS,
+  SET_SINGLE_SCREAM,
   LOADING_DATA,
   UNLIKE_SCREAM,
   LIKE_SCREAM,
@@ -19,12 +20,17 @@ const dataReducer = (state = initialState, { type, payload }) => {
       return { ...state, loading: true };
     case SET_SCREAMS:
       return { ...state, screams: payload, loading: false };
+    case SET_SINGLE_SCREAM:
+      return { ...state, scream: payload };
     case LIKE_SCREAM:
     case UNLIKE_SCREAM:
       let index = state.screams.findIndex(
         scream => scream.screamId === payload.screamId
       );
       state.screams[index] = payload;
+      if(state.scream.screamId === payload.screamId) {
+        state.scream = payload;
+      }
       return { ...state };
     case DELETE_SCREAM:
       let deleteIndex = state.screams.findIndex(

--- a/amistad-client/src/redux/types.js
+++ b/amistad-client/src/redux/types.js
@@ -6,6 +6,7 @@ export const UPDATE_FORM_DATA = "UPDATE_FORM_DATA";
 export const SET_LOADING_STATUS = "SET_LOADING_STATUS";
 export const SET_ERRORS = "SET_ERRORS";
 export const SET_SCREAMS = "SET_SCREAMS";
+export const SET_SINGLE_SCREAM = "SET_SINGLE_SCREAM";
 export const POST_SCREAM = "POST_SCREAM";
 export const LOADING_DATA = "LOADING_DATA";
 export const LIKE_SCREAM = "LIKE_SCREAM";

--- a/amistad-client/src/util/theme.js
+++ b/amistad-client/src/util/theme.js
@@ -42,6 +42,15 @@ export default {
       color: "red",
       fontSize: "0.8rem",
       marginTop: 10
+    },
+    hiddenRule: {
+      border: "none",
+      margin: 4
+    },
+    visibleRule: {
+      width: "100%",
+      borderBottom: "1px solid rgba(0, 0, 0, 0.1)",
+      marginBottom: 20
     }
   }
 };


### PR DESCRIPTION
## What does this PR do?
This PR implements the view single scream feature

## What major activities were carried out?
- create a scream dialog component to show individual scream
- create a comments component to show comments made on a scream
- write an action handle to handle fetching the singular scream from the backend
- write a reducer case to update the UI with the fetched scream

## How can this be manually tested?
- Clone the repository
- Fetch the branch
- Install the dependencies
- cd into the `amistad-client` folder
- Start project by running `npm start` in the terminal
- Your browser should automatically load to show you the homepage screen below:

![home with expand scream](https://user-images.githubusercontent.com/28527393/71788869-bc0bc580-3026-11ea-885c-a7e98f70e7b7.png)
- Click on the `expand` icon (vertically opposite arrows) in the lower far right corner of the scream card. If the scream does not have any comments, you should see something like this:

![single scream without comments](https://user-images.githubusercontent.com/28527393/71788955-959a5a00-3027-11ea-81ae-fbac79c48156.png)
- If the scream has comments, then, you should see something like this instead:

![single scream with comments](https://user-images.githubusercontent.com/28527393/71788921-4b18dd80-3027-11ea-9866-d90a68965e7a.png)