### PR TITLE
feat(user): implement user profile page

### DIFF
--- a/amistad-client/src/MyApp.js
+++ b/amistad-client/src/MyApp.js
@@ -15,6 +15,7 @@ import { logoutUser, getUserData } from "./redux/actions/userActions";
 import Navbar from "./components/layout/Navbar";
 // Pages
 import home from "./pages/home";
+import user from "./pages/user";
 import signup from "./pages/signup";
 import login from "./pages/login";
 
@@ -41,6 +42,7 @@ const MyApp = () => {
         <div className="container">
           <Switch>
             <Route exact path="/" component={home} />
+            <Route exact path="/user/:handle" component={user} />
             <AuthRoute exact path="/signup" component={signup} />
             <AuthRoute exact path="/login" component={login} />
           </Switch>

--- a/amistad-client/src/components/profile/Profile.js
+++ b/amistad-client/src/components/profile/Profile.js
@@ -12,7 +12,10 @@ import Typography from "@material-ui/core/Typography";
 import LocationOn from "@material-ui/icons/LocationOn";
 import LinkIcon from "@material-ui/icons/Link";
 import CalendarToday from "@material-ui/icons/CalendarToday";
-import { logoutUser, uploadProfileImage } from "../../redux/actions/userActions";
+import {
+  logoutUser,
+  uploadProfileImage
+} from "../../redux/actions/userActions";
 import EditDetails from "./EditDetails";
 import MyButton from "../../util/myButton";
 
@@ -64,7 +67,7 @@ const styles = theme => ({
   }
 });
 
-function Profile({ classes }) {
+const Profile = ({ classes }) => {
   const dispatch = useDispatch();
   const {
     credentials: { handle, createdAt, imageUrl, bio, website, location },
@@ -93,7 +96,7 @@ function Profile({ classes }) {
       <Paper className={classes.paper}>
         <div className={classes.profile}>
           <div className="image-wrapper">
-            <img src={imageUrl} alt="profile" className="profile-image" />
+            <img src={imageUrl} alt={handle} className="profile-image" />
             <input
               type="file"
               id="imageInput"
@@ -112,7 +115,7 @@ function Profile({ classes }) {
           <div className="profile-details">
             <MuiLink
               component={Link}
-              to={`/users/${handle}`}
+              to={`/user/${handle}`}
               color="primary"
               variant="h5"
             >
@@ -178,6 +181,6 @@ function Profile({ classes }) {
   ) : (
     <p>Loading...</p>
   );
-}
+};
 
 export default withStyles(styles)(Profile);

--- a/amistad-client/src/components/profile/StaticProfile.js
+++ b/amistad-client/src/components/profile/StaticProfile.js
@@ -1,0 +1,95 @@
+import React, { Fragment } from "react";
+import withStyles from "@material-ui/core/styles/withStyles";
+import dayjs from "dayjs";
+import MuiLink from "@material-ui/core/Link";
+import { Link } from "react-router-dom";
+import Typography from "@material-ui/core/Typography";
+import Paper from "@material-ui/core/Paper";
+import LocationOn from "@material-ui/icons/LocationOn";
+import LinkIcon from "@material-ui/icons/Link";
+import CalendarToday from "@material-ui/icons/CalendarToday";
+
+const styles = theme => ({
+  paper: {
+    padding: 20
+  },
+  profile: {
+    "& .image-wrapper": {
+      textAlign: "center",
+      position: "relative"
+    },
+    "& .profile-image": {
+      width: 200,
+      height: 200,
+      objectFit: "cover",
+      maxWidth: "100%",
+      borderRadius: "50%"
+    },
+    "& .profile-details": {
+      textAlign: "center",
+      "& span, svg": {
+        verticalAlign: "middle"
+      },
+      "& a": {
+        color: theme.palette.primary.main
+      }
+    },
+    "& hr": {
+      border: "none",
+      margin: "0 0 10px 0"
+    }
+  }
+});
+
+const StaticProfile = ({
+  classes,
+  profile: { handle, createdAt, imageUrl, bio, website, location }
+}) => {
+  return (
+    <Paper className={classes.paper}>
+      <div className={classes.profile}>
+        <div className="image-wrapper">
+          <img src={imageUrl} alt={handle} className="profile-image" />
+        </div>
+        <hr />
+        <div className="profile-details">
+          <MuiLink
+            component={Link}
+            to={`/users/${handle}`}
+            color="primary"
+            variant="h5"
+          >
+            @{handle}
+          </MuiLink>
+          <hr />
+          {bio && (
+            <Fragment>
+              <Typography variant="body2">{bio}</Typography>
+              <hr />
+            </Fragment>
+          )}
+          {location && (
+            <Fragment>
+              <LocationOn color="primary" /> <span>{location}</span>
+              <hr />
+            </Fragment>
+          )}
+          {website && (
+            <Fragment>
+              <LinkIcon color="primary" />
+              <a href={website} target="_blank" rel="noopener noreferrer">
+                {" "}
+                {website}
+              </a>
+              <hr />
+            </Fragment>
+          )}
+          <CalendarToday color="primary" />{" "}
+          <span>Joined {dayjs(createdAt).format("MMM YYYY")}</span>
+        </div>
+      </div>
+    </Paper>
+  );
+};
+
+export default withStyles(styles)(StaticProfile);

--- a/amistad-client/src/components/scream/Scream.js
+++ b/amistad-client/src/components/scream/Scream.js
@@ -58,14 +58,14 @@ const Scream = ({
         image={userImage}
         title={userHandle}
         component={Link}
-        to={`/users/${userHandle}`}
+        to={`/user/${userHandle}`}
       />
       <CardContent className={classes.content}>
         <Typography
           variant="h5"
           color="primary"
           component={Link}
-          to={`/users/${userHandle}`}
+          to={`/user/${userHandle}`}
         >
           {userHandle}
         </Typography>

--- a/amistad-client/src/components/scream/ScreamDialog.js
+++ b/amistad-client/src/components/scream/ScreamDialog.js
@@ -58,7 +58,7 @@ const ScreamDialog = ({ classes, screamId }) => {
       userHandle,
       comments
     },
-    loading
+    screamDialogLoading
   } = useSelector(state => ({ ...state.data }));
   const [open, setOpen] = useState(false);
   const dispatch = useDispatch();
@@ -73,7 +73,7 @@ const ScreamDialog = ({ classes, screamId }) => {
     dispatch({ type: SET_ERRORS, payload: { errors: {} } });
   };
 
-  const expandedScream = loading ? (
+  const expandedScream = screamDialogLoading ? (
     <div className={classes.spinnerDiv}>
       <CircularProgress size={200} thickness={2} />
     </div>

--- a/amistad-client/src/pages/home.js
+++ b/amistad-client/src/pages/home.js
@@ -13,9 +13,7 @@ const Home = () => {
   }, []);
 
   const { screams, loading } = useSelector(state => ({
-    ...state.data,
-    ...state.ui,
-    ...state.user
+    ...state.data
   }));
   const recentScreamsMarkup = !loading ? (
     screams.map(scream => <Scream key={scream.screamId} scream={scream} />)

--- a/amistad-client/src/pages/user.js
+++ b/amistad-client/src/pages/user.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { useSelector, useDispatch } from "react-redux";
+import Grid from "@material-ui/core/Grid";
+import Scream from "../components/scream/Scream";
+import StaticProfile from "../components/profile/StaticProfile";
+import { getUserDetails } from "../redux/actions/dataActions";
+
+const User = ({
+  match: {
+    params: { handle }
+  }
+}) => {
+  const [profile, setProfile] = useState(null);
+  const dispatch = useDispatch();
+  const { screams, userLoading } = useSelector(state => ({
+    ...state.data,
+    ...state.ui
+  }));
+
+  useEffect(() => {
+    getUserDetails(dispatch, handle);
+    const userProfile = async () => {
+      try {
+        const {
+          data: { user }
+        } = await axios.get(`/user/${handle}`);
+        setProfile(user);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    userProfile();
+  }, []);
+
+  const screamsMarkup = userLoading ? (
+    <p>Loading data...</p>
+  ) : screams.length === 0 ? (
+    <p>No screams from this user</p>
+  ) : (
+    screams.map(scream => <Scream key={scream.screamId} scream={scream} />)
+  );
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item sm={8} xs={12}>
+        {screamsMarkup}
+      </Grid>
+      <Grid item sm={4} xs={12}>
+        {profile === null ? (
+          <p>Loading Profile data</p>
+        ) : (
+          <StaticProfile profile={profile} />
+        )}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default User;

--- a/amistad-client/src/redux/actions/dataActions.js
+++ b/amistad-client/src/redux/actions/dataActions.js
@@ -3,6 +3,8 @@ import {
   SET_SINGLE_SCREAM,
   SET_ERRORS,
   SET_LOADING_STATUS,
+  SET_DIALOG_STATUS,
+  LOADING_USER_DATA,
   POST_SCREAM,
   LOADING_DATA,
   UNLIKE_SCREAM,
@@ -38,10 +40,16 @@ export const postScream = async (dispatch, newScream) => {
 
 export const getSingleScream = async (dispatch, screamId) => {
   try {
-    dispatch({ type: LOADING_DATA, payload: { loading: true } });
+    dispatch({
+      type: SET_DIALOG_STATUS,
+      payload: { screamDialogLoading: true }
+    });
     const { data: scream } = await axios.get(`${api.screams}/${screamId}`);
     dispatch({ type: SET_SINGLE_SCREAM, payload: scream });
-    dispatch({ type: LOADING_DATA, payload: { loading: false } });
+    dispatch({
+      type: SET_DIALOG_STATUS,
+      payload: { screamDialogLoading: false }
+    });
   } catch ({ response: { data } }) {
     console.log(data);
   }
@@ -86,7 +94,21 @@ export const deleteScream = async (dispatch, screamId) => {
   try {
     await axios.delete(`${api.screams}/${screamId}`);
     dispatch({ type: DELETE_SCREAM, payload: { screamId } });
-  } catch (error) {
-    console.log(error);
+  } catch ({ response: { data } }) {
+    console.log(data);
+  }
+};
+
+export const getUserDetails = async (dispatch, userHandle) => {
+  try {
+    dispatch({ type: LOADING_USER_DATA, payload: { userLoading: true } });
+    const {
+      data: { screams }
+    } = await axios.get(`/user/${userHandle}`);
+    dispatch({ type: SET_SCREAMS, payload: screams });
+    dispatch({ type: LOADING_USER_DATA, payload: { userLoading: false } });
+  } catch ({ response: { data } }) {
+    console.log(data);
+    dispatch({ type: SET_SCREAMS, payload: [] });
   }
 };

--- a/amistad-client/src/redux/reducers/dataReducer.js
+++ b/amistad-client/src/redux/reducers/dataReducer.js
@@ -2,7 +2,9 @@ import {
   SET_SCREAMS,
   SET_SINGLE_SCREAM,
   LOADING_DATA,
+  LOADING_USER_DATA,
   UNLIKE_SCREAM,
+  SET_DIALOG_STATUS,
   LIKE_SCREAM,
   DELETE_SCREAM,
   POST_SCREAM,
@@ -12,12 +14,16 @@ import {
 const initialState = {
   screams: [],
   scream: {},
-  loading: false
+  loading: false,
+  userLoading: false,
+  screamDialogLoading: false
 };
 
 const dataReducer = (state = initialState, { type, payload }) => {
   switch (type) {
     case LOADING_DATA:
+    case SET_DIALOG_STATUS:
+    case LOADING_USER_DATA:
       return { ...state, ...payload };
     case SET_SCREAMS:
       return { ...state, screams: payload, loading: false };

--- a/amistad-client/src/redux/types.js
+++ b/amistad-client/src/redux/types.js
@@ -9,6 +9,7 @@ export const SET_SCREAMS = "SET_SCREAMS";
 export const SET_SINGLE_SCREAM = "SET_SINGLE_SCREAM";
 export const POST_SCREAM = "POST_SCREAM";
 export const LOADING_DATA = "LOADING_DATA";
+export const LOADING_USER_DATA = "LOADING_USER_DATA";
 export const LIKE_SCREAM = "LIKE_SCREAM";
 export const UNLIKE_SCREAM = "UNLIKE_SCREAM";
 export const DELETE_SCREAM = "DELETE_SCREAM";


### PR DESCRIPTION
## What does this PR do?
This PR implements the user page feature

## What major activities were carried out?
- create user personal page component
- create action to handle UI updates and reducer to handle actions
- Style components

## How can this be manually tested?
- Clone the repository
- Fetch the branch
- Install the dependencies
- cd into the `amistad-client` folder
- Start project by running `npm start` in the terminal
- Your browser should automatically load to show you the homepage screen below:

![home with expand scream](https://user-images.githubusercontent.com/28527393/71788869-bc0bc580-3026-11ea-885c-a7e98f70e7b7.png)
- Click the `signup` button. You should see the following page:

![signup page](https://user-images.githubusercontent.com/28527393/71532515-fd4bf900-28f3-11ea-9fdf-6a60ad58ada6.png)

- Fill in the form details as appropriate, then submit. The browser should redirect to take you to the homepage with `screams`.

![authenticated homepage with expand scream](https://user-images.githubusercontent.com/28527393/71816688-abd60380-3083-11ea-8850-96489cfa91f1.png)
- Click on the user handle of any of the screams on the homepage (e.g. `user1`). It should take you to the user's page showing all of their screams and their profile details:

![user page showing user screams](https://user-images.githubusercontent.com/28527393/71843620-9cc37580-30c4-11ea-94a9-edd8362e78a2.png)